### PR TITLE
Create admin user management

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -29,3 +29,4 @@ main {
 .pagination li.active a {
   color: #fff;
 }
+

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,8 @@
 class UsersController < ApplicationController
 
-  before_action :logged_in_user, only: [:index, :edit, :update]
+  before_action :logged_in_user, only: [:index, :edit, :update, :destroy]
   before_action :correct_user, only: [:edit, :update]
+  before_action :admin_user, only: [:edit, :update, :destroy]
 
   def index
     @users = User.paginate(page: params[:page])
@@ -40,10 +41,21 @@ class UsersController < ApplicationController
     end
   end
 
+  def destroy
+    User.find(params[:id]).destroy
+    flash[:success] = "User deleted"
+    redirect_to users_url
+  end
+
   private
     def user_params
+      if (current_user)
       params.require(:user).permit(:name, :email, :password,
-                                   :password_confirmation)
+                                   :password_confirmation, :admin)
+      else
+      params.require(:user).permit(:name, :email, :password,
+                                :password_confirmation)
+      end
     end
 
     def logged_in_user
@@ -55,7 +67,11 @@ class UsersController < ApplicationController
 
     def correct_user
       @user = User.find(params[:id])
-      redirect_to(root_url) unless @user == current_user
+      redirect_to(root_url) unless @user == current_user || current_user.admin?
+    end
+
+    def admin_user
+      redirect_to(root_url) unless current_user.admin?
     end
 end
 

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -16,7 +16,20 @@
     <%= f.label :password_confirmation, "Confirmation" %>
     <%= f.password_field :password_confirmation %>
 </div>
+
+<% begin %>
+    <% if current_user.admin? %>
+        <div class="form-field">
+            <%= f.label :admin, class: "checkbox inline" do %>
+                <%= f.check_box :admin %>
+                <span>Enable as admin</span>
+            <% end %>
+        </div>
+    <% end %>
+<% rescue %>
+<% end %>
+<br> 
 <div class="form-field">
-     <%= f.submit yield(:button_text), class: "btn btn-primary" %>
+    <%= f.submit yield(:button_text), class: "btn btn-primary" %>
 </div>
 <% end %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,0 +1,11 @@
+<li class="collection-item avatar">
+    <i class="material-icons box green"> <%= gravatar_for user, size: 50 %></i>
+    <span class="title"><%= link_to user.name, user %></span>
+    <span>  
+    <% if current_user.admin? %>
+       | <%= link_to "delete", user, method: :delete,
+                                  data: { confirm: "You sure?" } %>,
+    <%= link_to "update", edit_user_path(user.id) %>
+    <% end %>
+    </span>
+</li>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -5,10 +5,7 @@
         <%= will_paginate %>
         <ul class="collection">
             <% @users.each do |user| %>
-            <li class="collection-item avatar">
-                <i class="material-icons box green"> <%= gravatar_for user, size: 50 %></i>
-                <span class="title"><%= link_to user.name, user %></span>
-            </li>
+                <%= render @users %>
             <% end %>
         </ul>
         <%= will_paginate %>

--- a/db/migrate/20190718034421_add_admin_to_users.rb
+++ b/db/migrate/20190718034421_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_16_132931) do
+ActiveRecord::Schema.define(version: 2019_07_18_034421) do
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 2019_07_16_132931) do
     t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,12 +1,14 @@
 User.create!(name:  "Admin User",
              email: "example@railstutorial.org",
              password:              "password",
-             password_confirmation: "password")
+             password_confirmation: "password",
+             admin: true)
 
 User.create!(name:  "Johnedel Mapa",
              email: "johnedel.mapa@sun-asterisk.com",
              password:              "password",
-             password_confirmation: "password")
+             password_confirmation: "password",
+             admin: true)
 
 49.times do |n|
   name  = Faker::Name.name


### PR DESCRIPTION
PR description: Admin user management module
Content: Admin users able to update and delete regular users
[Commands]
rails db:migrate:reset db:seed
rails server

[Pre-conditions]
Try to login as admin 
email: example@railstutorial.org 
password: password
then go to users tab
there should be delete and update function and if admin user 
click one of the users. the admin user has the capability to update the normal user to admin user and also update the user credentials.

Try to login as a normal user
email:example-4@railstutorial.org
password: password
then go to users tab. normal users has no capability to update nor delete users.

[Expected Output]
Admins user can update and delete normal users and also convert normal user to admin user.
			
[Notes]
N/A