### PR TITLE
Creation of Admin Choices

### DIFF
--- a/app/controllers/admin/words_controller.rb
+++ b/app/controllers/admin/words_controller.rb
@@ -15,6 +15,7 @@ module Admin
     def new
       @category = Category.find(params[:category_id])
       @word = @category.words.build
+      3.times { @word.choices.build }
     end
   
     def create
@@ -52,7 +53,7 @@ module Admin
     
     private
     def word_params
-      params.require(:word).permit(:content)
+      params.require(:word).permit(:content, choices_attributes: [:id, :content, :correct])
     end
   end
 end

--- a/app/models/choice.rb
+++ b/app/models/choice.rb
@@ -1,0 +1,3 @@
+class Choice < ApplicationRecord
+  belongs_to :word
+end

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -3,10 +3,12 @@ class Word < ApplicationRecord
   has_many :choices, dependent: :destroy
   accepts_nested_attributes_for :choices, allow_destroy: true,  reject_if: :all_blank
   validates :content, presence: true, length: { maximum: 50 }
-  default_scope -> { order(created_at: :desc) } 
+  default_scope -> { order(created_at: :desc) }
+ 
   
   def correct_ans
-    choices.find_by(correct: true)
+    choices.find_by(correct: true).try(:content)
   end
-   
+
+
 end

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -6,7 +6,7 @@ class Word < ApplicationRecord
   default_scope -> { order(created_at: :desc) } 
   
   def correct_ans
-    choices.find_by(correct: true).content
+    choices.find_by(correct: true)
   end
    
 end

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -1,5 +1,12 @@
 class Word < ApplicationRecord
   belongs_to :category
+  has_many :choices, dependent: :destroy
+  accepts_nested_attributes_for :choices, allow_destroy: true,  reject_if: :all_blank
   validates :content, presence: true, length: { maximum: 50 }
   default_scope -> { order(created_at: :desc) } 
+  
+  def correct_ans
+    choices.find_by(correct: true).content
+  end
+   
 end

--- a/app/views/admin/words/_form.html.erb
+++ b/app/views/admin/words/_form.html.erb
@@ -2,10 +2,18 @@
     <%= render 'shared/error_messages', object: @word %>
     <div class="form-field">
         <%= f.label :content, "Word" %>
-        <%= f.text_field :content %>
+        <%= f.text_field :content %>    
     </div>
     <div class="form-field">
-    </div>
+        <%= f.label "Choices" %>
+        <%= f.fields_for :choices do |choice| %>
+            <%= choice.text_field :content %>
+            <%= choice.label :correct, class: "checkbox inline" do %>
+                <%= choice.check_box :correct %>
+                <span>Correct</span>
+            <% end %>
+        <% end %>
+    </div> 
     <br>
     <div class="form-field">
         <%= f.submit yield(:button_text), class: "btn btn-primary" %>

--- a/app/views/admin/words/index.html.erb
+++ b/app/views/admin/words/index.html.erb
@@ -18,7 +18,7 @@
                 <% @words.each do |word| %>
                 <tr>
                     <td><%= word.content %></td>
-                    <td><%= word.correct_ans%></td>
+                    <td><%= word.correct_ans.content%></td>
                     <td>
                     <%= link_to "Edit", edit_admin_category_word_path(@category, word), 
                     class: 'btn blue lighten-1' %> 

--- a/app/views/admin/words/index.html.erb
+++ b/app/views/admin/words/index.html.erb
@@ -18,7 +18,7 @@
                 <% @words.each do |word| %>
                 <tr>
                     <td><%= word.content %></td>
-                    <td><%= word.correct_ans.content%></td>
+                    <td><%= word.correct_ans %></td>
                     <td>
                     <%= link_to "Edit", edit_admin_category_word_path(@category, word), 
                     class: 'btn blue lighten-1' %> 

--- a/app/views/admin/words/index.html.erb
+++ b/app/views/admin/words/index.html.erb
@@ -18,7 +18,7 @@
                 <% @words.each do |word| %>
                 <tr>
                     <td><%= word.content %></td>
-                    <td> Not Working for now </td>
+                    <td><%= word.correct_ans%></td>
                     <td>
                     <%= link_to "Edit", edit_admin_category_word_path(@category, word), 
                     class: 'btn blue lighten-1' %> 

--- a/db/migrate/20190723034257_create_choices.rb
+++ b/db/migrate/20190723034257_create_choices.rb
@@ -1,0 +1,10 @@
+class CreateChoices < ActiveRecord::Migration[5.2]
+  def change
+    create_table :choices do |t|
+      t.references :word, foreign_key: true
+      t.string :content
+      t.string :correct, default: false 
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_22_061554) do
+ActiveRecord::Schema.define(version: 2019_07_23_034257) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "choices", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "word_id"
+    t.string "content"
+    t.string "correct", default: "0"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["word_id"], name: "index_choices_on_word_id"
   end
 
   create_table "relationships", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -47,5 +56,6 @@ ActiveRecord::Schema.define(version: 2019_07_22_061554) do
     t.index ["category_id"], name: "index_words_on_category_id"
   end
 
+  add_foreign_key "choices", "words"
   add_foreign_key "words", "categories"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,18 +34,3 @@ followers = users[3..40]
 following.each { |followed| user1.follow(followed) }
 followers.each { |follower| follower.follow(user1) }
 
-49.times do |n|
-  title  = Faker::Book.title
-  des = "Lorem Ipsums"
-
-  Category.create!(title:  title,
-                  description: des)
-end
-
-2.times do |n|
-  word  =  Faker::Book.title
-  id = 1
-
-  Word.create!(content:  word,
-                  category_id: id)
-end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,3 +34,11 @@ followers = users[3..40]
 following.each { |followed| user1.follow(followed) }
 followers.each { |follower| follower.follow(user1) }
 
+49.times do |n|
+  title  = Faker::Book.title
+  des = "Lorem Ipsums"
+
+  Category.create!(title:  title,
+                  description: des)
+end
+

--- a/test/fixtures/choices.yml
+++ b/test/fixtures/choices.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  content: MyString
+  correct: MyString
+  boolean: MyString
+  word: one
+
+two:
+  content: MyString
+  correct: MyString
+  boolean: MyString
+  word: two

--- a/test/models/choice_test.rb
+++ b/test/models/choice_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ChoiceTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
PR description: Creation of Admin Choices
Content: Admin choices and answer
[Commands]
rails db:migrate:reset db:seed
rails server

[Pre-conditions]
Login as admin 
email: example@railstutorial.org
password: password

Go to manage categories choose a category and click add word
it should redirect to the index page of word with title and content

Now click add word
It should allow users to add words, choices, and the correct answer.  user could also update and delete words

[Expected Output]
Admin user can CRUD words and assign choices and correct answer
			
[Notes]
Validation is still not working for the choices, which user can choose more than 1 correct answer. I will work on that tomorrow for the polish of admin side.